### PR TITLE
Jt/add sorting for foreignkey parents

### DIFF
--- a/lib/MySQL/Diff.pm
+++ b/lib/MySQL/Diff.pm
@@ -121,6 +121,7 @@ sub diff {
     for my $table1 ($self->db1->tables()) {
         my $diffs;
         my $name = $table1->name();
+	my $parents = $table1->parents();
         $used_tables{'-- '. $name} = 1;
         debug(4, "table 1 $name = ".Dumper($table1));
         debug(2,"looking at tables called '$name'");
@@ -135,12 +136,13 @@ sub diff {
             #     unless $self->{opts}{'only-both'} || $self->{opts}{'keep-old-tables'};
         }
         $unsorted_changes{$name}{'diffs'}=$diffs;
-        $unsorted_changes{$name}{'parents'}=$table1->$parents();
+        $unsorted_changes{$name}{'parents'}=$parents;
     }
 
     for my $table2 ($self->db2->tables()) {
         my $diffs;
         my $name = $table2->name();
+	my $parents = $table2->parents();
         $used_tables{'-- '. $name} = 1;
         debug(4, "table 2 $name = ".Dumper($table2));
         if (! $self->db1->table_by_name($name)) {
@@ -151,13 +153,13 @@ sub diff {
             #     unless $self->{opts}{'only-both'};
         }
         $unsorted_changes{$name}{'diffs'}=$diffs;
-        $unsorted_changes{$name}{'parents'}=$table2->$parents();
+        $unsorted_changes{$name}{'parents'}=$parents;
     }
-
+    
     # Sort for Parents
     my %checked_changes;
     debug(1,"Start sorting for parental constraints");
-
+    debug(1,"Lets see: ".Dumper(%unsorted_changes));
     foreach my $t (keys %unsorted_changes) {
         debug(1,"Checking table: ".$t);
         push @changes, add($t);
@@ -178,7 +180,7 @@ sub diff {
         }else{
             debug(1, $table." has no parents, returning");
             $checked_changes{$table} = "done";
-            return $unsorted_changes{$table}{'diff'};
+            return $unsorted_changes{$table}{'diffs'};
         }
     
         my @tmparray;
@@ -187,7 +189,7 @@ sub diff {
             push @tmparray, add($parent);
         }
         $checked_changes{$table} = "done";
-        push @tmparray, $unsorted_changes{$table}{'diff'};
+        push @tmparray, $unsorted_changes{$table}{'diffs'};
         return @tmparray;
     }
     debug(1,"Finished sorting for parental constraints");

--- a/lib/MySQL/Diff.pm
+++ b/lib/MySQL/Diff.pm
@@ -223,7 +223,7 @@ sub _diff_banner {
 
     my $opt_text =
         join ', ',
-            map { $self->{opts}{$_} eq '1' ? $_ : "$_=$self->{opts}{$_}" }
+            map { $self->{opts}{$_} eq '1' ? $_ : "$_=$self->{opts}{$_}"  unless $_ eq "password" }
                 keys %{$self->{opts}};
     $opt_text = "## Options: $opt_text\n" if $opt_text;
 

--- a/lib/MySQL/Diff/Table.pm
+++ b/lib/MySQL/Diff/Table.pm
@@ -155,6 +155,7 @@ sub field           { my $self = shift; return $self->{fields}{$_[0]};  }
 sub fields          { my $self = shift; return $self->{fields};         }
 sub primary_key     { my $self = shift; return $self->{primary_key};    }
 sub indices         { my $self = shift; return $self->{indices};        }
+sub parents         { my $self = shift; return $self->{parents};        }
 sub partitions      { my $self = shift; return $self->{partitions};     }
 sub options         { my $self = shift; return $self->{options};        }
 sub foreign_key     { my $self = shift; return $self->{foreign_key};    }
@@ -207,6 +208,10 @@ sub _parse {
         
         if (/^(?:CONSTRAINT\s+(.*)?)?\s+FOREIGN\s+KEY\s+(.*)$/) {
             my ($key, $val) = ($1, $2);
+            if (/^(?:CONSTRAINT\s+(.*)?)?\s+FOREIGN\s+KEY\s+\((.+?)\)\sREFERENCES\s(.+?)\s\((.+?)\)(.*)/) {
+              my ($const_name, $const_local_column, $const_parent_table, $const_parent_column, $const_options) = ($1, $2, $3, $4, $5);
+              $self->{parent}{$const_name} = $const_parent_table;
+            }
             croak "foreign key '$key' duplicated in table '$name'\n"
                 if $self->{foreign_key}{$key};
             debug(1,"got foreign key $key");

--- a/lib/MySQL/Diff/Table.pm
+++ b/lib/MySQL/Diff/Table.pm
@@ -15,6 +15,7 @@ MySQL::Diff::Table - Table Definition Class
   my $fields        = $db->fields();                # %$fields
   my $primary_key   = $db->primary_key();
   my $indices       = $db->indices();               # %$indices
+  my $parents       = $db->parents();               # %$parents
   my $partitions    = $db->partitions();            # %$partitions
   my $options       = $db->options();
 
@@ -103,6 +104,10 @@ Returns a hash reference to fields used as primary key fields.
 =item * indices
 
 Returns a hash reference to fields used as index fields.
+
+=item * parents
+
+Returns a hash reference to fields used as parents.
 
 =item * partitions
 
@@ -210,7 +215,7 @@ sub _parse {
             my ($key, $val) = ($1, $2);
             if (/^(?:CONSTRAINT\s+(.*)?)?\s+FOREIGN\s+KEY\s+\((.+?)\)\sREFERENCES\s(.+?)\s\((.+?)\)(.*)/) {
               my ($const_name, $const_local_column, $const_parent_table, $const_parent_column, $const_options) = ($1, $2, $3, $4, $5);
-              $self->{parents}{$const_name} = $const_parent_table;
+              $self->{parents}{$const_parent_table} = $const_name;
             }
             croak "foreign key '$key' duplicated in table '$name'\n"
                 if $self->{foreign_key}{$key};

--- a/lib/MySQL/Diff/Table.pm
+++ b/lib/MySQL/Diff/Table.pm
@@ -210,7 +210,7 @@ sub _parse {
             my ($key, $val) = ($1, $2);
             if (/^(?:CONSTRAINT\s+(.*)?)?\s+FOREIGN\s+KEY\s+\((.+?)\)\sREFERENCES\s(.+?)\s\((.+?)\)(.*)/) {
               my ($const_name, $const_local_column, $const_parent_table, $const_parent_column, $const_options) = ($1, $2, $3, $4, $5);
-              $self->{parent}{$const_name} = $const_parent_table;
+              $self->{parents}{$const_name} = $const_parent_table;
             }
             croak "foreign key '$key' duplicated in table '$name'\n"
                 if $self->{foreign_key}{$key};


### PR DESCRIPTION
dumping tables is done alphabetically: FK constraints have parent tables which need independent ordering