### PR TITLE
Fix toleration and colation

### DIFF
--- a/lib/MySQL/Diff.pm
+++ b/lib/MySQL/Diff.pm
@@ -279,6 +279,7 @@ sub _diff_fields {
             if ($fields2 && $f2) {
                 if ($self->{opts}{tolerant}) {
                     for ($f1, $f2) {
+                        s/ CHARACTER SET [\w_]+//gi;
                         s/ COLLATE [\w_]+//gi;
                     }
                 }


### PR DESCRIPTION
```
root@8a9a6cc50186:/# diff /tmp/live.sql /tmp/code.sql 
10c10
<     name                CHAR(255),
---
>     name                CHAR(255) COLLATE utf8mb4_general_ci,
```

but it recognizes a change.

```
root@8a9a6cc50186:/# mysql-schema-diff --tolerant --no-old-defs -P 3306 -h localhost -u mx3 --password=mx3 /tmp/live.sql /tmp/code.sql
Variable "%checked_changes" will not stay shared at /usr/share/perl5/MySQL/Diff.pm line 174.
Variable "%unsorted_changes" will not stay shared at /usr/share/perl5/MySQL/Diff.pm line 181.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
mysql: [Warning] Using a password on the command line interface can be insecure.
## mysqldiff 0.60
## 
## Run on Fri Jan 12 09:48:23 2024
## Options: host=localhost, tolerant, no-old-defs, debug=0, user=mx3, 1, port=3306
##
## --- file: /tmp/live.sql
## +++ file: /tmp/code.sql

ALTER TABLE applicants CHANGE COLUMN name name char(255) CHARACTER SET utf8mb4 DEFAULT NULL;
```

debug:

Table 1:
```
line: [name char(255) COLLATE utf8mb4_bin DEFAULT NULL]
got field def 'name': char(255) COLLATE utf8mb4_bin DEFAULT NULL
```

Field:
```
'name' => 'char(255) COLLATE utf8mb4_bin DEFAULT NULL',
```

Table 2:
```
line: [name char(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL]
got field def 'name': char(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL
```

Field:
```
'name' => 'char(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL',
```


mysqldump adds an explicit `character set X` if the collation does not match the tables collation.