### PR TITLE
Add event support

### DIFF
--- a/bin/mysqldiff
+++ b/bin/mysqldiff
@@ -77,6 +77,10 @@ non-interactively patch database1 to match database2
 
 enable debugging [level N, default 1]
 
+=item C<-e,  --events>
+
+include mysql events
+
 =item C<-l,  --list-tables>
 
 output the list off all used tables
@@ -92,6 +96,10 @@ don't output DROP TABLE commands
 =item C<-c,  --keep-old-columns>
 
 don't output DROP COLUMN commands
+
+=item C<-E,  --keep-old-events>
+
+don't output DROP EVENT commands
 
 =item C<-n,  --no-old-defs>
 
@@ -206,9 +214,9 @@ use String::ShellQuote qw(shell_quote);
 use MySQL::Diff;
 
 my %opts = ();
-GetOptions(\%opts, "help|?", "debug|d:i", "apply|A", "batch-apply|B",
-           "keep-old-tables|k", "keep-old-columns|c", "no-old-defs|n",
-           "only-both|o", "table-re|t=s",
+GetOptions(\%opts, "help|?", "debug|d:i", "events|e", "apply|A", "batch-apply|B",
+           "keep-old-tables|k", "keep-old-columns|c", "keep-old-events|E",
+           "no-old-defs|n", "only-both|o", "table-re|t=s",
            "host|h=s", "port|P=s", "socket|s=s", "user|u=s", "password|p:s",
            "host1=s",  "port1=s",  "socket1=s",  "user1=s",  "password1:s",
            "host2=s",  "port2=s",  "socket2=s",  "user2=s",  "password2:s",
@@ -245,10 +253,12 @@ Options:
   -A,  --apply               interactively patch database1 to match database2
   -B,  --batch-apply         non-interactively patch database1 to match database2
   -d,  --debug[=N]           enable debugging [level N, default 1]
+  -e,  --events              output mysql events
   -l,  --list-tables         output the list off all used tables
   -o,  --only-both           only output changes for tables in both databases
   -k,  --keep-old-tables     don't output DROP TABLE commands
   -c,  --keep-old-columns    don't output DROP COLUMN commands
+  -E,  --keep-old-events     don't output DROP EVENT commands
   -n,  --no-old-defs         suppress comments describing old definitions
   -t,  --table-re=REGEXP     restrict comparisons to tables matching REGEXP
   -i,  --tolerant            ignore DEFAULT, AUTO_INCREMENT, COLLATE, and formatting changes

--- a/lib/MySQL/Diff/Event.pm
+++ b/lib/MySQL/Diff/Event.pm
@@ -1,0 +1,114 @@
+package MySQL::Diff::Event;
+
+=head1 NAME
+
+MySQL::Diff::Event - Event Definition Class
+
+=head1 SYNOPSIS
+
+  use MySQL::Diff::Event
+
+  my $db = MySQL::Diff::Event->new(%options);
+  my $def           = $db->def();
+  my $name          = $db->name();
+  my $definer       = $db->definer();
+
+=head1 DESCRIPTION
+
+Parses an event definition into component parts.
+
+=cut
+
+use warnings;
+use strict;
+
+our $VERSION = '0.60';
+
+# ------------------------------------------------------------------------------
+# Libraries
+
+use Carp qw(:DEFAULT);
+use MySQL::Diff::Utils qw(debug);
+
+# ------------------------------------------------------------------------------
+
+=head1 METHODS
+
+=head2 Constructor
+
+=over 4
+
+=item new( %options )
+
+Instantiate the objects, providing the command line options for database
+access and process requirements.
+
+=cut
+
+sub new {
+    my $class = shift;
+    my %hash  = @_;
+    my $self = {};
+    bless $self, ref $class || $class;
+
+    $self->{$_} = $hash{$_} for(keys %hash);
+
+    debug(3,"\nconstructing new MySQL::Diff::Event");
+    croak "MySQL::Diff::Event::new called without def params" unless $self->{def};
+    $self->_parse;
+    return $self;
+}
+
+=back
+
+=head2 Public Methods
+
+Fuller documentation will appear here in time :)
+
+=over 4
+
+=item * def
+
+Returns the event definition as a string.
+
+=item * name
+
+Returns the name of the current event.
+
+=back
+
+=cut
+
+sub def             { my $self = shift; return $self->{def};            }
+sub name            { my $self = shift; return $self->{name};           }
+sub schedule        { my $self = shift; return $self->{schedule};       }
+sub preserve        { my $self = shift; return $self->{preserve};       }
+sub enable          { my $self = shift; return $self->{enable};         }
+sub body            { my $self = shift; return $self->{body};         }
+#
+# ------------------------------------------------------------------------------
+# Private Methods
+
+sub _parse {
+    my $self = shift;
+
+    $self->{def} =~ s/\n+/\n/;
+    $self->{lines} = [ grep ! /^\s*$/, split /(?=^)/m, $self->{def} ];
+    my @lines = @{$self->{lines}};
+    debug(4,"parsing event def: '$self->{def}'");
+
+    my $name;
+    my $all_lines = join "\n", @lines;
+    if ($all_lines =~ /^\/\*!\d{5}\sCREATE\*\/\s\/\*!\d{5}\sDEFINER=(\S+)\*\/\s\/\*!\d{5}\sEVENT\s`(\w+)`\sON SCHEDULE (.*)\sON COMPLETION (PRESERVE|NOT PRESERVE)\s(ENABLE|DISABLE)\sDO\s(.*?)\s\*\//ms) {
+        $self->{definer} = $1;
+        $self->{name} = $2;
+        $self->{schedule} = $3;
+        $self->{preserve} = $4;
+        $self->{enable} = $5;
+        $self->{body} = $6;
+        debug(3,"got event name '$self->{name}'");
+        shift @lines;
+    } else {
+        croak "couldn't figure out event name";
+    }
+}

--- a/lib/MySQL/Diff/Table.pm
+++ b/lib/MySQL/Diff/Table.pm
@@ -8,27 +8,27 @@ MySQL::Diff::Table - Table Definition Class
 
   use MySQL::Diff::Table
 
-  my $db = MySQL::Diff::Database->new(%options);
-  my $def           = $db->def();
-  my $name          = $db->name();
-  my $field         = $db->field();
-  my $fields        = $db->fields();                # %$fields
-  my $primary_key   = $db->primary_key();
-  my $indices       = $db->indices();               # %$indices
-  my $parents       = $db->parents();               # %$parents
-  my $partitions    = $db->partitions();            # %$partitions
-  my $options       = $db->options();
-  my $engine        = $db->engine();
-  my $charset       = $db->charset();
-  my $collate       = $db->collate();
+  my $table = MySQL::Diff::Table->new(%options);
+  my $def           = $table->def();
+  my $name          = $table->name();
+  my $field         = $table->field();
+  my $fields        = $table->fields();                # %$fields
+  my $primary_key   = $table->primary_key();
+  my $indices       = $table->indices();               # %$indices
+  my $parents       = $table->parents();               # %$parents
+  my $partitions    = $table->partitions();            # %$partitions
+  my $options       = $table->options();
+  my $engine        = $table->engine();
+  my $charset       = $table->charset();
+  my $collate       = $table->collate();
 
-  my $isfield       = $db->isa_field($field);
-  my $isprimary     = $db->isa_primary($field);
-  my $isindex       = $db->isa_index($field);
-  my $isunique      = $db->is_unique($field);
-  my $isspatial     = $db->is_spatial($field);
-  my $isfulltext    = $db->is_fulltext($field);
-  my $ipatitioned   = $db->is_paritioned($field);
+  my $isfield       = $table->isa_field($field);
+  my $isprimary     = $table->isa_primary($field);
+  my $isindex       = $table->isa_index($field);
+  my $isunique      = $table->is_unique($field);
+  my $isspatial     = $table->is_spatial($field);
+  my $isfulltext    = $table->is_fulltext($field);
+  my $ipatitioned   = $table->is_paritioned($field);
 
 =head1 DESCRIPTION
 
@@ -163,7 +163,7 @@ Returns 1 if given field is defined as an auto increment field, otherwise return
 
 =item * is_paritioned
 
-Returns if given fiel is a praritioned field
+Returns if given field is a paritioned field
 
 =back
 
@@ -228,7 +228,7 @@ sub _parse {
 
             next;
         }
-        
+
         if (/^(?:CONSTRAINT\s+(.*)?)?\s+FOREIGN\s+KEY\s+(.*)$/) {
             my $val = $2;
             if (/^(?:CONSTRAINT\s+(.*)?)?\s+FOREIGN\s+KEY\s+\((.+?)\)\sREFERENCES\s(.+?)\s\((.+?)\)(.*)/) {
@@ -236,7 +236,7 @@ sub _parse {
               debug(1,"new foreign key $const_local_column-$const_parent_table-$const_parent_column");
               my $key = "$self->{name}_${const_local_column}_${const_parent_table}_${const_parent_column}";
 
-              $self->{parents}{$const_parent_table} = $key; 
+              $self->{parents}{$const_parent_table} = $key;
               croak "foreign key '$key' duplicated in table '$name'\n"
                   if $self->{foreign_key}{$key};
               debug(1,"got foreign key $key");
@@ -287,7 +287,7 @@ sub _parse {
               debug(4,"options contained $1 $2 $3");
             } else {
               debug(1,"no regexp match for option content");
-            } 
+            }
             if ($ending){ # there is a ; at the end 
               debug(4,"got table options '$self->{options}'");
               last;

--- a/lib/MySQL/Diff/Utils.pm
+++ b/lib/MySQL/Diff/Utils.pm
@@ -88,10 +88,10 @@ is equal to or lower than the current debug level.
                 return;
             }
         }
-        
+
         print STDERR @_,"\n";
     }
-    
+
 }
 
 1;


### PR DESCRIPTION
This PR should add event support to mysqldiff, enabled by the `--events|-e` flag (plus a `-keep-old-events|-E` bonus flag 😉 )

Stuff worth mentioning:

- `mysqldiff` was taking a bit of a naive approach to to definition parsing. Namely it assumed the _only_ definitions for a database would be tables. Thus, it merely `split` the entire definition string on any mention of `(create|alter|drop) table`. Yeah... unfortunately that's not the case anymore, so I had to rely on the crutch of coupling the parsing to the mysqldump formatting. That is: assuming that there are separating comments for the table definitions and the event definitions, and splitting the defs for both tables and events using that. Perhaps there are better ways of doing that, but none as simple as that (I think). We care about this because these defs are then used wholesale when we need to create a table/event, so we cannot allow any junk that doesn't strictly belong to appear on the defs. Maybe there's a better way of doing this, I'm not sure, but this seemed good enough (since we're normalising tables via mysqldump anyways, this will only break if mysqldump changes dump formats)
- Are we sure the tests pass? I've found myself failing quite a few old tests, but maybe that's an issue with my setup, no idea. Had to end up relying on manual runs with the very same test tables to make sure the output was correct.
- Yeah I've fixed some formatting stuff, my vim was marking it in red and it bothered me 😄 